### PR TITLE
Enable sliding window for ragged prefill

### DIFF
--- a/python/tvm/relax/frontend/nn/llm/kv_cache.py
+++ b/python/tvm/relax/frontend/nn/llm/kv_cache.py
@@ -219,8 +219,8 @@ class PagedKVCache(Object):  # pylint: disable=too-few-public-methods
         """Fine-grained API that appends the MHA K/V data to KV cache."""
         # pylint: disable=protected-access
         b, s, h_kv, d_qk = k._expr.struct_info.shape
-        b, s, h_kv, d_qk = v._expr.struct_info.shape
         k = k.reshape(b * s, h_kv, d_qk)
+        b, s, h_kv, d_qk = v._expr.struct_info.shape
         v = v.reshape(b * s, h_kv, d_qk)
         return PagedKVCache(
             _expr=rx.call_pure_packed(

--- a/python/tvm/relax/frontend/nn/llm/kv_cache.py
+++ b/python/tvm/relax/frontend/nn/llm/kv_cache.py
@@ -214,6 +214,25 @@ class PagedKVCache(Object):  # pylint: disable=too-few-public-methods
         o = Tensor(_expr=bb.emit(rx.TupleGetItem(attn_results, 0))).reshape(b, s, h_qo, v_head_dim)
         lse = Tensor(_expr=bb.emit(rx.TupleGetItem(attn_results, 1))).reshape(b, s, h_qo)
         return o, lse
+    
+    def append_mha_kv(self, layer_id: int, k: Tensor, v: Tensor) -> "PagedKVCache":
+        """Fine-grained API that appends the MHA K/V data to KV cache."""
+        # pylint: disable=protected-access
+        b, s, h_kv, d_qk = k._expr.struct_info.shape
+        b, s, h_kv, d_qk = v._expr.struct_info.shape
+        k = k.reshape(b * s, h_kv, d_qk)
+        v = v.reshape(b * s, h_kv, d_qk)
+        return PagedKVCache(
+            _expr=rx.call_pure_packed(
+                "vm.builtin.attention_kv_cache_append_mha_kv",
+                self._expr,
+                rx.PrimValue(layer_id),  # type: ignore[arg-type]
+                k._expr,
+                v._expr,
+                sinfo_args=rx.ObjectStructInfo(),
+            ),
+            _name="paged_kv_cache",
+        )
 
     def append_mla_kv(self, layer_id: int, kv: Tensor) -> "PagedKVCache":
         """Fine-grained API that appends the MLA K/V data to KV cache."""

--- a/src/runtime/vm/attn_backend.h
+++ b/src/runtime/vm/attn_backend.h
@@ -285,7 +285,7 @@ class RaggedPrefillFunc : public AttnBackendFunc {
       : AttnBackendFunc(std::move(attn_func), attn_kind, backend_kind) {}
 
   virtual void MHA(Tensor q, Tensor k, Tensor v, Tensor qo_indptr, Tensor kv_indptr,
-                   Tensor q_rope_position, Tensor k_rope_pos_offset, bool causal,
+                   Tensor q_rope_position, Tensor k_rope_pos_offset, int sliding_window_size, bool causal,
                    RoPEMode rope_mode, double rotary_scale, double rotary_theta, double sm_scale,
                    Tensor attn_output, Tensor attn_lse, TVMStreamHandle compute_stream) {
     LOG(FATAL) << "MHA computation is not supported by the current backend";
@@ -307,11 +307,11 @@ class TIRRaggedPrefillFunc : public RaggedPrefillFunc {
       : RaggedPrefillFunc(std::move(attn_func), attn_kind, AttnBackendKind::kTIR) {}
 
   void MHA(Tensor q, Tensor k, Tensor v, Tensor qo_indptr, Tensor kv_indptr, Tensor q_rope_position,
-           Tensor k_rope_pos_offset, bool causal, RoPEMode rope_mode, double rotary_scale,
+           Tensor k_rope_pos_offset, int sliding_window_size, bool causal, RoPEMode rope_mode, double rotary_scale,
            double rotary_theta, double sm_scale, Tensor attn_output, Tensor attn_lse,
            TVMStreamHandle compute_stream) final {
     attn_func_(q, qo_indptr, k, v, kv_indptr, q_rope_position, k_rope_pos_offset, attn_output,
-               attn_lse, static_cast<int64_t>(causal),
+               attn_lse, sliding_window_size, static_cast<int64_t>(causal),
                /*rotary_mode=*/static_cast<int64_t>(rope_mode == RoPEMode::kInline), rotary_scale,
                rotary_theta, sm_scale);
   }
@@ -329,7 +329,7 @@ class FlashInferRaggedPrefillFunc : public RaggedPrefillFunc {
         plan_func_(std::move(plan_func)) {}
 
   void MHA(Tensor q, Tensor k, Tensor v, Tensor qo_indptr, Tensor kv_indptr, Tensor q_rope_position,
-           Tensor k_rope_pos_offset, bool causal, RoPEMode rope_mode, double rotary_scale,
+           Tensor k_rope_pos_offset, int sliding_window_size, bool causal, RoPEMode rope_mode, double rotary_scale,
            double rotary_theta, double sm_scale, Tensor attn_output, Tensor attn_lse,
            TVMStreamHandle compute_stream) final {
     Device device = q->device;

--- a/src/runtime/vm/kv_state.cc
+++ b/src/runtime/vm/kv_state.cc
@@ -94,6 +94,11 @@ TVM_FFI_STATIC_INIT_BLOCK() {
              kv_cache->CrossAttention(layer_id, std::move(q_data), std::move(o_data),
                                       std::move(lse_data), sm_scale);
            })
+      .def("vm.builtin.attention_kv_cache_append_mha_kv",
+           [](AttentionKVCache kv_cache, int64_t layer_id, Tensor k_data, Tensor v_data) {
+             kv_cache->AppendMHAKV(layer_id, std::move(k_data), std::move(v_data));
+             return kv_cache;
+           })
       .def("vm.builtin.attention_kv_cache_append_mla_kv",
            [](AttentionKVCache kv_cache, int64_t layer_id, Tensor kv_data) {
              kv_cache->AppendMLAKV(layer_id, std::move(kv_data));

--- a/src/runtime/vm/kv_state.h
+++ b/src/runtime/vm/kv_state.h
@@ -207,6 +207,14 @@ class AttentionKVCacheObj : public KVStateObj {
                               double sm_scale) = 0;
 
   /*!
+   * \brief Fine-grained API that appends the MHA K/V data to KV cache.
+   * \param layer_id The model layer where the attention compute happens.
+   * \param k_data The input K data to append, in layout `(num_total_length, num_kv_heads, qk_head_dim)`.
+   * \param v_data The input V data to append, in layout `(num_total_length, num_kv_heads, qk_head_dim)`.
+   */
+  virtual void AppendMHAKV(int64_t layer_id, Tensor k_data, Tensor v_data) = 0;
+
+  /*!
    * \brief Fine-grained API that appends the MLA K/V data to KV cache.
    * \param layer_id The model layer where the attention compute happens.
    * \param kv_data The input KV data to append, in layout `(total_length, qk_head_dim)`.

--- a/src/runtime/vm/paged_kv_cache.cc
+++ b/src/runtime/vm/paged_kv_cache.cc
@@ -101,6 +101,8 @@ class PagedAttentionKVCacheObj : public AttentionKVCacheObj {
   const bool support_sliding_window_;
   /*! \brief A boolean flag indicating if the KV cache has per layer sliding window. */
   const bool support_layer_sliding_window_;
+  /*! \brief The sliding window size for sliding window attention. */
+  int32_t sliding_window_size_;
   /*! \brief The attention kinds for each layer. */
   const std::vector<AttnKind> attn_kinds_;
 
@@ -314,6 +316,7 @@ class PagedAttentionKVCacheObj : public AttentionKVCacheObj {
                                     : support_sliding_window),
         support_layer_sliding_window_(std::find(attn_kinds.begin(), attn_kinds.end(),
                                                 AttnKind::kMHASliding) != attn_kinds.end()),
+        sliding_window_size_(-1),
         attn_kinds_(std::move(attn_kinds)),
         rope_mode_(support_sliding_window && rope_mode != RoPEMode::kNone ? RoPEMode::kInline
                                                                           : rope_mode),
@@ -766,6 +769,8 @@ class PagedAttentionKVCacheObj : public AttentionKVCacheObj {
     // introduce more sink. Therefore, we update the given attn sink size.
     it->second.last_block_attn_sink_size = std::max(attn_sink_size - prefix_length, 0);
     it->second.sliding_window_size = sliding_window_size;
+    if (sliding_window_size_ == -1)
+      sliding_window_size_ = sliding_window_size;
   }
 
   void PopN(int64_t seq_id, int32_t n) final {
@@ -1408,8 +1413,8 @@ class PagedAttentionKVCacheObj : public AttentionKVCacheObj {
     // The auxiliary data structure on device must have been synchronized.
     ICHECK(!dirty_aux_data_device_);
 
-    if (attn_kind == AttnKind::kMHA) {
-      MHASelfAttnInternal(q_data, k_data, v_data, o_data, lse_data, sm_scale);
+    if (attn_kind == AttnKind::kMHA || attn_kind == AttnKind::kMHASliding) {
+      MHASelfAttnInternal(layer_id, q_data, k_data, v_data, o_data, lse_data, sm_scale);
     } else {
       MLASelfAttnInternal(q_data, k_data, v_data, o_data, lse_data, sm_scale);
     }
@@ -2089,7 +2094,7 @@ class PagedAttentionKVCacheObj : public AttentionKVCacheObj {
     if (!append_before_attn_) {
       // The first part of attention, which only involves the q and the newly appended k/v.
       is_first_kernel = false;
-      MHASelfAttnInternal(q_data, k_data, v_data, output, merged_attn_lse_view_, sm_scale);
+      MHASelfAttnInternal(local_layer_id, q_data, k_data, v_data, output, merged_attn_lse_view_, sm_scale);
     }
     bool self_attn_computed = !is_first_kernel;
     bool cross_attn_computed = MHACrossAttnInternal(
@@ -2098,15 +2103,21 @@ class PagedAttentionKVCacheObj : public AttentionKVCacheObj {
         << "Both self-attention and cross-attention are not computed.";
   }
 
-  void MHASelfAttnInternal(Tensor q_data, Tensor k_data, Tensor v_data, Tensor o_data,
+  void MHASelfAttnInternal(int64_t local_layer_id, Tensor q_data, Tensor k_data, Tensor v_data, Tensor o_data,
                            Tensor lse_data, double sm_scale) {
     if (is_chain_on_depths_[0]) {
       // If the batch does not form a tree, use raggedness prefill kernel.
+
+      int sliding_window_size =
+          (!support_sliding_window_ &&
+           attn_kinds_[local_layer_id + layer_id_begin_offset_] != AttnKind::kMHASliding)
+              ? -1
+              : sliding_window_size_;
       ICHECK_NOTNULL(f_attention_prefill_ragged_);
       f_attention_prefill_ragged_->MHA(
           q_data, k_data, v_data, cur_append_length_indptr_view_, cur_append_length_indptr_view_,
-          q_rope_position_map_view_, k_ragged_rope_pos_offset_view_, /*causal=*/true, rope_mode_,
-          rotary_scale_, rotary_theta_, sm_scale, o_data, lse_data, compute_stream_);
+          q_rope_position_map_view_, k_ragged_rope_pos_offset_view_, sliding_window_size, /*causal=*/true,
+          rope_mode_, rotary_scale_, rotary_theta_, sm_scale, o_data, lse_data, compute_stream_);
     } else {
       // The batch requires tree attention.
       ICHECK(f_attention_prefill_with_tree_mask_ != nullptr)
@@ -2127,8 +2138,8 @@ class PagedAttentionKVCacheObj : public AttentionKVCacheObj {
     ICHECK_NOTNULL(f_attention_prefill_ragged_);
     f_attention_prefill_ragged_->MHA(
         q_data, k_data, v_data, cur_append_length_indptr_view_, cur_append_length_indptr_view_,
-        q_rope_position_map_view_, k_ragged_rope_pos_offset_view_, /*causal=*/true, RoPEMode::kNone,
-        rotary_scale_, rotary_theta_, sm_scale, o_data, lse_data, compute_stream_);
+        q_rope_position_map_view_, k_ragged_rope_pos_offset_view_, -1, /*causal=*/true,
+        RoPEMode::kNone, rotary_scale_, rotary_theta_, sm_scale, o_data, lse_data, compute_stream_);
   }
 
   /*! \brief Compute cross-attention for MHA. Return if there is effective computation. */

--- a/src/runtime/vm/paged_kv_cache.cc
+++ b/src/runtime/vm/paged_kv_cache.cc
@@ -1464,6 +1464,39 @@ class PagedAttentionKVCacheObj : public AttentionKVCacheObj {
     }
   }
 
+  void AppendMHAKV(int64_t layer_id, Tensor k_data, Tensor v_data) final {
+    // Shape and dtype check.
+    int64_t local_layer_id = layer_id - layer_id_begin_offset_;
+    CHECK_GE(local_layer_id, 0);
+    CHECK_LT(local_layer_id, num_layers_);
+    Tensor pages = pages_[local_layer_id];
+    CHECK(k_data.DataType() == pages.DataType());
+    CHECK(v_data.DataType() == pages.DataType());
+    CHECK(attn_kinds_[layer_id] == AttnKind::kMLA);
+
+    // k_data: (num_total_length, num_kv_heads, qk_head_dim)
+    CHECK_EQ(k_data->ndim, 3);
+    // v_data: (num_total_length, num_kv_heads, qk_head_dim)
+    CHECK_EQ(v_data->ndim, 3);
+    int64_t total_seq_length = 0;
+    for (int64_t seq_id = 0; seq_id < cur_batch_size_; ++seq_id) {
+      total_seq_length += cur_append_lengths_[seq_id];
+    }
+    CHECK_LE(k_data->shape[0], total_seq_length);
+    CHECK_LE(k_data->shape[1], total_seq_length);
+    CHECK_LE(v_data->shape[0], num_kv_heads_);
+    CHECK_LE(v_data->shape[1], num_kv_heads_);
+    CHECK_LE(k_data->shape[2], qk_head_dim_);
+    CHECK_LE(v_data->shape[2], qk_head_dim_);
+    // Sync the copy stream and the compute stream.
+    ComputeStreamWaitForCopyStream();
+    // The auxiliary data structure on device must have been synchronized.
+    ICHECK(!dirty_aux_data_device_);
+
+    CHECK(f_transpose_append_mha_.defined());
+    f_transpose_append_mha_.value()(pages_[local_layer_id], k_data, v_data, append_position_map_view_);
+  }
+
   void AppendMLAKV(int64_t layer_id, Tensor kv_data) final {
     // Shape and dtype check.
     int64_t local_layer_id = layer_id - layer_id_begin_offset_;


### PR DESCRIPTION
## Description
This PR enables the following features in PagedKVCache
- Enable sliding window for ragged prefill (`PagedKVCache.self_attention()`)
- Add `AppendMHAKV()`(`PagedKVCache.append_mha_kv()`) as public API

## Note
This PR is only for `brekkylab/relax`. There would be another PR for `apache/tvm`.